### PR TITLE
Fix pthread linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,12 +118,13 @@ set(buildable_programs "")
 
 find_library(SNDFILE sndfile)
 if (SNDFILE)
+    find_package (Threads)
     add_executable(quiet_encode_file programs/encode_file.c)
-    target_link_libraries(quiet_encode_file quiet_static sndfile)
+    target_link_libraries(quiet_encode_file quiet_static sndfile ${CMAKE_THREAD_LIBS_INIT})
     set(buildable_programs ${buildable_programs} quiet_encode_file)
 
     add_executable(quiet_decode_file programs/decode_file.c)
-    target_link_libraries(quiet_decode_file quiet_static sndfile)
+    target_link_libraries(quiet_decode_file quiet_static sndfile ${CMAKE_THREAD_LIBS_INIT})
     set(buildable_programs ${buildable_programs} quiet_decode_file)
 else()
     unset(SNDFILE CACHE)
@@ -137,12 +138,13 @@ from building its file generating programs. you can get libsndfile from
 endif()
 
 if (PORTAUDIO)
+    find_package (Threads)
     add_executable(quiet_encode_soundcard programs/encode_soundcard.c)
-    target_link_libraries(quiet_encode_soundcard quiet_static)
+    target_link_libraries(quiet_encode_soundcard quiet_static ${CMAKE_THREAD_LIBS_INIT})
     set(buildable_programs ${buildable_programs} quiet_encode_soundcard)
 
     add_executable(quiet_decode_soundcard programs/decode_soundcard.c)
-    target_link_libraries(quiet_decode_soundcard quiet_static)
+    target_link_libraries(quiet_decode_soundcard quiet_static ${CMAKE_THREAD_LIBS_INIT})
     set(buildable_programs ${buildable_programs} quiet_decode_soundcard)
 endif()
 


### PR DESCRIPTION
I don't really know what I'm doing at all, never used CMake, but I was getting this error:

```
/usr/bin/ld: lib/libquiet_static.a(error.c.o): undefined reference to symbol 'pthread_once@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

And [this Stack Overflow answer](http://stackoverflow.com/a/4774027/990590) suggested that I do this. So I did.

Works now. Let me know if I should solve it a different way. If it helps, I was using [this Dockerfile](https://gist.github.com/iameli/7e58dd972302ad88b406ad9c4a9bcbbf) to compile the project.
